### PR TITLE
Have generated bitmaps be the size of the puzzle

### DIFF
--- a/MarioPicrossRipper.csproj
+++ b/MarioPicrossRipper.csproj
@@ -53,6 +53,7 @@
       <DependentUpon>Form1.cs</DependentUpon>
     </Compile>
     <Compile Include="src\Picross.cs" />
+    <Compile Include="src\PixelPerfectPictureBox.cs" />
     <Compile Include="src\Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="src\PuzzleDrawer.cs" />

--- a/src/Form1.Designer.cs
+++ b/src/Form1.Designer.cs
@@ -62,7 +62,7 @@
             this.puzzleImageBox.Margin = new System.Windows.Forms.Padding(2);
             this.puzzleImageBox.Name = "puzzleImageBox";
             this.puzzleImageBox.Size = new System.Drawing.Size(291, 267);
-            this.puzzleImageBox.SizeMode = System.Windows.Forms.PictureBoxSizeMode.CenterImage;
+            this.puzzleImageBox.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
             this.puzzleImageBox.TabIndex = 1;
             this.puzzleImageBox.TabStop = false;
             // 

--- a/src/Form1.Designer.cs
+++ b/src/Form1.Designer.cs
@@ -30,7 +30,7 @@
         {
             this.openRomDialog = new System.Windows.Forms.OpenFileDialog();
             this.openRomButton = new System.Windows.Forms.Button();
-            this.puzzleImageBox = new System.Windows.Forms.PictureBox();
+            this.puzzleImageBox = new PixelPerfectPictureBox();
             this.puzzleIndexBar = new System.Windows.Forms.TrackBar();
             this.indexTextBox = new System.Windows.Forms.TextBox();
             ((System.ComponentModel.ISupportInitialize)(this.puzzleImageBox)).BeginInit();
@@ -87,9 +87,9 @@
             // 
             // Form1
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(647, 283);
+            this.ClientSize = new System.Drawing.Size(485, 230);
             this.Controls.Add(this.indexTextBox);
             this.Controls.Add(this.puzzleIndexBar);
             this.Controls.Add(this.puzzleImageBox);
@@ -110,7 +110,7 @@
 
         private System.Windows.Forms.OpenFileDialog openRomDialog;
         private System.Windows.Forms.Button openRomButton;
-        private System.Windows.Forms.PictureBox puzzleImageBox;
+        private PixelPerfectPictureBox puzzleImageBox;
         private System.Windows.Forms.TrackBar puzzleIndexBar;
         private System.Windows.Forms.TextBox indexTextBox;
     }

--- a/src/PixelPerfectPictureBox.cs
+++ b/src/PixelPerfectPictureBox.cs
@@ -1,0 +1,23 @@
+﻿using System.Drawing.Drawing2D;
+using System.Windows.Forms;
+
+namespace MarioPicrossRipper
+{
+	/// <summary>
+	/// Inherits from PictureBox; adds Interpolation Mode Setting
+	/// </summary>
+	public class PixelPerfectPictureBox : PictureBox
+	{
+		/// <summary>
+		/// The Interpolation Mode to use when drawing the image.
+		/// This is set to Nearest Neighbor by default to maintain the pixel-perfect look of the original low-resolution image.
+		/// </summary>
+		public InterpolationMode InterpolationMode { get; set; } = InterpolationMode.NearestNeighbor;
+
+		protected override void OnPaint(PaintEventArgs paintEventArgs)
+		{
+			paintEventArgs.Graphics.InterpolationMode = InterpolationMode;
+			base.OnPaint(paintEventArgs);
+		}
+	}
+}

--- a/src/PuzzleDrawer.cs
+++ b/src/PuzzleDrawer.cs
@@ -1,4 +1,5 @@
-﻿using System.Drawing;
+﻿using System;
+using System.Drawing;
 
 namespace MarioPicrossRipper
 {
@@ -6,26 +7,17 @@ namespace MarioPicrossRipper
     {
         public Bitmap PuzzleToBitmap(Picross puzzle)
         {
-            Bitmap bmp = new Bitmap(160, 150);
-            int index = 0;
-            Graphics g = Graphics.FromImage(bmp);
-            for (int y = 0; y < bmp.Height / 10; y++)
+            var bmp = new Bitmap(puzzle.Width, puzzle.Height);
+            var g = Graphics.FromImage(bmp);
+
+            for (var i = 0; i < puzzle.PuzzleData.Length; i++)
             {
-                for(int x = 0; x < bmp.Width / 10; x++)
-                {
-                    if(puzzle.PuzzleData[index] == 1)
-                    {
-                        //bmp.SetPixel(x, y, Color.Black);
-                        g.FillRectangle(Brushes.Black, x * 10, y * 10, 10, 10);
-                    }
-                    else
-                    {
-                        //bmp.SetPixel(x, y, Color.White);
-                        g.FillRectangle(Brushes.White, x * 10, y * 10, 10, 10);
-                    }
-                    index++;
-                }
+                var x = i % 16;
+                var y = i / 16;
+                var color = puzzle.PuzzleData[i] == 1 ? Brushes.Black : Brushes.White;
+                g.FillRectangle(color, x, y, 1, 1);
             }
+            
             return bmp;
         }
 


### PR DESCRIPTION
Closes #3.

This PR initialises the bitmaps to be the size of the puzzle, instead of 160x150. I also added a `PixelPerfectPictureBox` WinForm component in order to be able to show these tiny bitmaps, without them becoming blurry. It does this by using nearest neighbor when resampling the images.